### PR TITLE
9300: overlay enable samsung stk

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -112,4 +112,6 @@
          config to 7. -->
     <integer name="config_deviceHardwareKeys">7</integer>
 
+    <!-- Boolean to enable stk functionality on Samsung phones -->
+    <bool name="config_samsung_stk">true</bool>
 </resources>


### PR DESCRIPTION
- i9300 uses same RIL as i9100 what was originally my development phone
  tested and working

Change-Id: I96724d1587249b7fb3acafea8ccd64fcddea26cc
